### PR TITLE
Use civi master for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "require": {
-        "cweagans/composer-patches": "1.7",
-        "civicrm/civicrm-core": "5.44",
-        "civicrm/civicrm-packages": "5.44",
+        "cweagans/composer-patches": ">=1.7",
+        "civicrm/civicrm-core": "dev-master",
+        "civicrm/civicrm-packages": "dev-master",
         "civicrm/civicrm-asset-plugin": "~1.1"
     },
     "config": {


### PR DESCRIPTION
I'm not clear on why it's 5.44? I'm thinking it should follow the civi releases, and the core PR is against master, so the master branch here would use master, and when it branches/tags alongside core is when it would select a specific version.

(I would love to get rid of composer as a side goal, but that would be a totally separate project. I assume the target audience here would prefer tarballs.)

For patches, I made it `>=` so that when core updates this won't artificially constrain it. Basically this just declares _a_ dependency, and then it would use core's.

I haven't included a composer.lock update because somehow (composer?!?!) my local has locked php to v8 so it won't even run with php 7.