### PR TITLE
Nginx tweaks

### DIFF
--- a/nginx-site.conf.example
+++ b/nginx-site.conf.example
@@ -157,7 +157,7 @@ server {
   # then create a separate rule that covers strictly what you expect and nothing wider.
   # You want to ensure that any files a developer might accidentally create/leave around
   # like backups, sql dumps etc. are not world-accessible.
-  location ~ ^/(public|core|ext)/.*\.(png|css|jpg|js|mjs|gif|ico|svg|woff2|html)$ {
+  location ~ ^/(public|core|ext)/.*\.(png|css|jpg|js|mjs|json|webp|gif|ico|svg|woff2|html)$ {
     # Return the file if it exists, or a 404
     try_files $uri 404;
   }

--- a/nginx-site.conf.example
+++ b/nginx-site.conf.example
@@ -169,6 +169,14 @@ server {
     fastcgi_pass php-fpm;
   }
 
+
+  # @todo If you have migrated from Drupal7 and moved your images
+  # to the new location, you can use something like this which will
+  # allow requests to the old paths to serve the images from their new paths.
+  # location /sites/default/files/civicrm/persist/contribute/images/ {
+  #   alias /var/www/example.org/docroot/public/media/images/;
+  # }
+
   # Default location.
   location / {
     return 404;


### PR DESCRIPTION
Mosaico (which exists to make migration as fun as sticking sandpaper behind your eyelids) needs the browser to be able to access json files from the ext dir.

This change, which also allows webp, because it seemed an omission, also allows these extensions from public and core. But perhaps it shouldn't? I'm not super sure about json in /ext/; I think there's some extension cache which could reveal which extensions are present.

Thoughts?

Also added a note re migrating images so they don't break old mailings.