### PR TITLE
Tweak nginx docroot for clarity

### DIFF
--- a/nginx-site.conf.example
+++ b/nginx-site.conf.example
@@ -62,7 +62,13 @@ server {
 server {
   listen 443 ssl;
   server_name example.org;
-  root /var/www/example.org/;
+  # The docroot is the directory in which you find the index.php file.
+  # If you extract a zip file from the releases page, you'll see everything
+  # under a civicrm-standalone dir. You can rename it whatever you want
+  # (e.g. docroot or web or publicHtml are common) - it doesn't matter
+  # as long as the following path points to it.
+  root /var/www/example.org/civicrm-standalone;
+
   charset utf-8;
 
   error_log /var/log/nginx/error.log;


### PR DESCRIPTION
A number of mattermost posts have indicated that people are confused by where to place the files from the release bundle, they end up with them in a subdir of their docroot, whereas the dir extracted from the bundle actually needs to be the docroot itself.

I've attempted to align this example file's docroot with our practice of naming the top dir in the bundle "civicrm-standalone", and added a comment to explain what is going on.