### PR TITLE
Make composer install faster

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,9 @@
         "civicrm/civicrm-asset-plugin": "~1.1"
     },
     "config": {
-        "preferred-install": "source",
+        "preferred-install": {
+            "civicrm/*": "source"
+        },
         "allow-plugins": {
             "civicrm/civicrm-asset-plugin": true,
             "cweagans/composer-patches": true,


### PR DESCRIPTION
This is the same thing we do in buildkit for drupal8 and what I do on dev drupal8 installs: https://github.com/civicrm/civicrm-buildkit/blob/438b309d28ba11a7d96e402656bd74fa22e133a1/src/civibuild.lib.sh#L646

It's 8000x times faster (source: I made-up that number).
Since downloading source via git for the various vendor libraries is rarely useful and just slows it down.